### PR TITLE
#6: cleaner output from tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,14 +74,15 @@ version = "0.1.0"
 dependencies = [
  "anymap",
  "assemble-macros",
+ "atty",
  "backtrace",
  "clap",
  "colored",
- "convert_case",
  "crossbeam",
  "dirs",
  "fern",
  "glob",
+ "heck",
  "include_dir",
  "indicatif",
  "itertools",
@@ -95,9 +96,11 @@ dependencies = [
  "reqwest",
  "ron",
  "serde",
+ "serde_json",
  "static_assertions",
  "tempfile",
  "thiserror",
+ "thread_local",
  "time",
  "url",
  "uuid",
@@ -175,9 +178,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
+checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
 dependencies = [
  "addr2line",
  "cc",
@@ -208,9 +211,9 @@ checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "f0b3de4a0c5e67e16066a0715723abd91edc2f9001d09c46e1dca929351e130e"
 
 [[package]]
 name = "cc"
@@ -226,9 +229,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.5"
+version = "3.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53da17d37dba964b9b3ecb5c5a1f193a2762c700e6829201e645b9381c99dc7"
+checksum = "54635806b078b7925d6e36810b1755f2a4b5b4d57560432c1ecf60bcbe10602b"
 dependencies = [
  "atty",
  "bitflags",
@@ -243,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.5"
+version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11d40217d16aee8508cc8e5fde8b4ff24639758608e5374e731b53f85749fb9"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -256,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -288,12 +291,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
 dependencies = [
  "cfg-if",
  "crossbeam-channel",
@@ -334,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -344,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -355,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
+checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -369,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
+checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -379,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff1f980957787286a554052d03c7aee98d99cc32e09f6d45f0a814133c87978"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -409,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "encode_unicode"
@@ -430,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
@@ -448,21 +445,21 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0408e2626025178a6a7f7ffc05a25bc47103229f19c113755de7bf63816290c"
+checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -566,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
 name = "glob"
@@ -597,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -652,9 +649,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.19"
+version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42dc3c131584288d375f2d07f822b0cb012d8c6fb899a5b9fdb3cb7eb9b6004f"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -792,9 +789,9 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "log"
@@ -843,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
@@ -904,24 +901,24 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.28.4"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "openssl"
-version = "0.10.40"
+version = "0.10.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb81a6430ac911acb25fe5ac8f1d2af1b4ea8a4fdfda0f1ee4292af2e2d8eb0e"
+checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -951,9 +948,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.74"
+version = "0.9.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835363342df5fba8354c5b453325b110ffd54044e588c539cf2f20a8014e4cb1"
+checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
 dependencies = [
  "autocfg",
  "cc",
@@ -964,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.1.0"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 
 [[package]]
 name = "percent-encoding"
@@ -1034,18 +1031,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
@@ -1106,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "534cfe58d6a18cc17120fbf4635d53d14691c1fe4d951064df9bd326178d7d5a"
 dependencies = [
  "bitflags",
 ]
@@ -1126,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1137,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"
@@ -1260,18 +1257,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1280,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "itoa",
  "ryu",
@@ -1303,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.24"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707d15895415db6628332b737c838b88c598522e4dc70647e59b72312924aebc"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
  "indexmap",
  "ryu",
@@ -1315,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "simple_logger"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75a9723083573ace81ad0cdfc50b858aa3c366c48636edb4109d73122a0c0ea"
+checksum = "166fea527c36d9b8a0a88c0c6d4c5077c699d9ffb5cf890b231a3f08c35f3d40"
 dependencies = [
  "atty",
  "colored",
@@ -1328,9 +1325,12 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "socket2"
@@ -1356,9 +1356,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d6785e2e6b8442eb26736eaef8c8f0ce0e575c1457d06c3f2812f9cb4c8a0"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1436,6 +1436,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "threadpool"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,9 +1455,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
 dependencies = [
  "itoa",
  "libc",
@@ -1479,10 +1488,11 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.19.2"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
+checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -1546,9 +1556,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
  "once_cell",
 ]
@@ -1567,15 +1577,15 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
 dependencies = [
  "tinyvec",
 ]

--- a/crates/assemble-core/Cargo.toml
+++ b/crates/assemble-core/Cargo.toml
@@ -47,7 +47,10 @@ regex = "1.5.6"
 backtrace = "0.3.65"
 anymap = "0.12.1"
 ron = "0.7.1"
-convert_case = "0.5.0"
+heck = "0.4.0"
+thread_local = "1.1.4"
+serde_json = "1.0.82"
+atty = "0.2.14"
 
 [dev-dependencies]
 more_collection_macros = "0.2.2"

--- a/crates/assemble-core/src/defaults/tasks/tasks_report.rs
+++ b/crates/assemble-core/src/defaults/tasks/tasks_report.rs
@@ -8,8 +8,7 @@ use crate::task::up_to_date::UpToDate;
 use crate::task::{CreateTask, HasTaskId, InitializeTask};
 use crate::{BuildResult, Executable, Project, Task};
 use colored::Colorize;
-use convert_case::Case;
-use convert_case::Casing;
+use heck::ToTitleCase;
 use log::{debug, info, trace};
 use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
@@ -64,7 +63,7 @@ impl Task for TaskReport {
 
         for task_id in tasks {
             let mut handle = container.get_task(&task_id)?;
-            debug!("got task handle {:?}", handle);
+            trace!("got task handle {:?}", handle);
 
             if handle.task_id() == task.task_id() {
                 trace!("skipping because its this task and self-referential tasks cause cycles");
@@ -107,12 +106,12 @@ impl Task for TaskReport {
         };
 
         for (group, task_info) in group_to_tasks {
-            if !match_group(&group) {
+            if !match_group(&group.to_lowercase()) {
                 continue;
             }
             info!(
                 "{}",
-                format!("{} tasks:", group.to_case(Case::Title)).underline()
+                format!("{} tasks:", group.to_title_case()).underline()
             );
             for task_info in task_info {
                 info!("  {}", task_info);

--- a/crates/assemble-core/src/identifier.rs
+++ b/crates/assemble-core/src/identifier.rs
@@ -292,7 +292,7 @@ impl TryFrom<String> for TaskId {
 }
 
 /// How projects are referenced. Unlike tasks, projects don't have to have parents.
-#[derive(Default, Eq, PartialEq, Clone, Hash)]
+#[derive(Default, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct ProjectId(Id);
 
 impl ProjectId {

--- a/crates/assemble-core/src/logging.rs
+++ b/crates/assemble-core/src/logging.rs
@@ -1,21 +1,29 @@
 //! Defines different parts of the logging utilities for assemble-daemon
 
-use crate::identifier::TaskId;
-use fern::{Dispatch, FormatCallback};
+use crate::identifier::{ProjectId, TaskId};
+use fern::{Dispatch, FormatCallback, Output};
 use indicatif::ProgressBar;
 use log::{log, logger, set_logger, Level, LevelFilter, Log, Metadata, Record, SetLoggerError};
 use once_cell::sync::{Lazy, OnceCell};
 use std::any::Any;
-use std::collections::HashMap;
-use std::fmt::format;
-use std::io::stdout;
+use std::collections::{HashMap, VecDeque};
+use std::fmt::{Display, format, Formatter};
+use std::io::{BufRead, BufReader, ErrorKind, stdout, Write};
 use std::path::Path;
-use std::sync::{Arc, RwLock};
-use std::thread::ThreadId;
-use std::{fmt, thread};
+use std::sync::{Arc, Mutex, RwLock};
+use std::thread::{JoinHandle, ThreadId};
+use std::{fmt, io, thread};
+use std::cell::{Cell, RefCell};
+use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{channel, Receiver, Sender, TryRecvError};
+use std::time::{Duration, Instant};
+use atty::Stream;
+use thread_local::ThreadLocal;
 use time::format_description::FormatItem;
 use time::macros::format_description;
 use time::{format_description, OffsetDateTime};
+use crate::text_factory::AssembleFormatter;
 
 /// Provides helpful logging args for clap clis
 #[derive(Debug, clap::Args)]
@@ -55,20 +63,55 @@ pub struct LoggingArgs {
     #[clap(conflicts_with_all(&["error", "warn", "info", "debug"]))]
     #[clap(display_order = 5)]
     trace: bool,
+
+    /// Outputs everything as json
+    #[clap(long)]
+    pub json: bool,
+
+    #[clap(long, value_enum, default_value_t = ConsoleMode::Auto)]
+    console: ConsoleMode
 }
 
-#[derive(Default)]
+#[derive(Default, Eq, PartialEq)]
 pub enum OutputType {
     #[default]
     Basic,
     TimeOnly,
     Complicated,
+    Json
+}
+
+#[derive(Debug, Copy, Clone, clap::ValueEnum)]
+#[repr(u8)]
+pub enum ConsoleMode {
+    Auto,
+    Advanced,
+    Plain
+}
+
+
+
+impl ConsoleMode {
+
+    pub fn resolve(self) -> Self {
+        match &self {
+            ConsoleMode::Auto => {
+                if atty::is(Stream::Stdout) {
+                    ConsoleMode::Advanced
+                } else {
+                    ConsoleMode::Plain
+                }
+            }
+            ConsoleMode::Advanced => { self }
+            ConsoleMode::Plain => { self }
+        }
+    }
 }
 
 impl LoggingArgs {
     /// Get the level filter from this args
     fn config_from_settings(&self) -> (LevelFilter, OutputType) {
-        if self.error {
+        let mut out = if self.error {
             (LevelFilter::Error, OutputType::Basic)
         } else if self.warn {
             (LevelFilter::Warn, OutputType::Basic)
@@ -80,19 +123,21 @@ impl LoggingArgs {
             (LevelFilter::Trace, OutputType::TimeOnly)
         } else {
             (LevelFilter::Info, OutputType::Basic)
+        };
+        if self.json {
+            out.1 = OutputType::Json;
         }
+        out
     }
 
-    pub fn init_root_logger(&self) -> bool {
-        self.create_logger().apply().is_ok()
+    pub fn init_root_logger(&self) -> Result<Option<JoinHandle<()>>, SetLoggerError> {
+        let (dispatch, handle) = self.create_logger();
+        dispatch.apply()
+            .map(|_| handle)
     }
 
     pub fn init_root_logger_with(filter: LevelFilter, mode: OutputType) {
-        Dispatch::new()
-            .format(Self::message_format(mode, false))
-            .level(filter)
-            .chain(stdout())
-            .apply()
+        Self::try_init_root_logger_with(filter, mode)
             .expect("couldn't create dispatch");
     }
 
@@ -100,19 +145,40 @@ impl LoggingArgs {
         filter: LevelFilter,
         mode: OutputType,
     ) -> Result<(), SetLoggerError> {
-        Dispatch::new()
-            .format(Self::message_format(mode, false))
-            .level(filter)
-            .chain(stdout())
+        Self::create_logger_with(filter, mode, None)
             .apply()
     }
 
-    pub fn create_logger(&self) -> Dispatch {
+    pub fn create_logger(&self) -> (Dispatch, Option<JoinHandle<()>>) {
         let (filter, output_mode) = self.config_from_settings();
-        Dispatch::new()
-            .format(Self::message_format(output_mode, self.show_source))
+        let mut handle = None;
+        let output = match self.console.resolve() {
+            ConsoleMode::Auto => { unreachable!()}
+            ConsoleMode::Advanced => {
+                let (started, made_handle) = start_central_logger();
+                handle = Some(made_handle);
+                let central = CentralLoggerInput {
+                    sender: started
+                };
+                Some(Output::from(Box::new(central) as Box<dyn Write + Send>))
+            }
+            ConsoleMode::Plain => { None }
+        };
+        (Self::create_logger_with(filter, output_mode, output), handle)
+    }
+
+    pub fn create_logger_with(filter: LevelFilter, mode: OutputType, output: impl Into<Option<Output>>) -> Dispatch {
+        let mut dispatch = Dispatch::new()
             .level(filter)
-            .chain(stdout())
+            .chain(output.into().unwrap_or(Output::stdout("\n")));
+        match mode {
+            OutputType::Json => {
+                dispatch.format(Self::json_message_format)
+            }
+            other => {
+                dispatch.format(Self::message_format(other, false))
+            }
+        }
     }
 
     fn message_format(
@@ -120,19 +186,36 @@ impl LoggingArgs {
         show_source: bool,
     ) -> impl Fn(FormatCallback, &fmt::Arguments, &log::Record) + Sync + Send + 'static {
         move |out, message, record| {
-            out.finish(format_args!(
-                "{}{}",
-                {
-                    let prefix = Self::format_prefix(&output_mode, record, show_source);
-                    if prefix.is_empty() {
-                        prefix
-                    } else {
-                        format!("{} ", prefix)
-                    }
-                },
-                message
-            ))
-        }
+                out.finish(format_args!(
+                    "{}{}",
+                    {
+                        let prefix = Self::format_prefix(&output_mode, record, show_source);
+                        if prefix.is_empty() {
+                            prefix
+                        } else {
+                            format!("{} ", prefix)
+                        }
+                    },
+                    message
+                ))
+            }
+
+    }
+
+    fn json_message_format(format: FormatCallback, args: &fmt::Arguments, record: &log::Record) {
+        let message = format!("{}", args);
+        let level = record.level();
+        let origin = Origin::None;
+
+        let message_info = JsonMessageInfo {
+            level,
+            origin,
+            message
+        };
+
+        let as_string = serde_json::to_string(&message_info).unwrap();
+
+        format.finish(format_args!("{}", as_string));
     }
 
     fn format_prefix(output_mode: &OutputType, record: &Record, show_source: bool) -> String {
@@ -181,6 +264,7 @@ impl LoggingArgs {
                     level_string
                 )
             }
+            _ => {unreachable!()}
         };
         if show_source {
             if let Some(source) = record.module_path() {
@@ -201,62 +285,219 @@ pub fn init_root_log(level: LevelFilter, mode: impl Into<Option<OutputType>>) {
     let _ = LoggingArgs::try_init_root_logger_with(level, mode);
 }
 
-/// Modifies the logging output of the program by intercepting stdout.
-#[derive(Debug)]
-pub struct TaskProgressDisplay {
-    inner: Arc<RwLock<TaskProgressDisplayInner>>,
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Hash)]
+pub enum Origin {
+    Project(ProjectId),
+    Task(TaskId),
+    None
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct JsonMessageInfo {
+    #[serde(with = "LevelDef")]
+    pub level: Level,
+    pub origin: Origin,
+    pub message: String
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Level")]
+enum LevelDef {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+static THREAD_ORIGIN: Lazy<ThreadLocal<RefCell<Origin>>> = Lazy::new(|| ThreadLocal::new() );
+
+fn thread_origin() -> Origin {
+    THREAD_ORIGIN.get_or(|| RefCell::new(Origin::None))
+        .borrow()
+        .clone()
+}
+
+pub fn in_project(project: ProjectId) {
+    let origin = THREAD_ORIGIN.get_or(|| RefCell::new(Origin::None));
+    let mut ref_mut = origin.borrow_mut();
+    *ref_mut = Origin::Project(project);
+    // trace!("set origin to {:?}", ref_mut);
+}
+
+pub fn in_task(task: TaskId) {
+    let origin = THREAD_ORIGIN.get_or(|| RefCell::new(Origin::None));
+    let mut ref_mut = origin.borrow_mut();
+    *ref_mut = Origin::Task(task);
+    // trace!("set origin to {:?}", ref_mut);
+}
+
+pub fn reset() {
+    let origin = THREAD_ORIGIN.get_or(|| RefCell::new(Origin::None));
+    let mut ref_mut = origin.borrow_mut();
+    *ref_mut = Origin::None;
+    // trace!("set origin to {:?}", ref_mut);
+}
+
+
+pub fn stop_logging() {
+    let lock = LOG_COMMAND_SENDER.get()
+        .unwrap();
+    let sender = lock
+        .lock()
+        .unwrap();
+
+    sender.send(LoggingCommand::Stop);
+}
+
+static CONTINUE_LOGGING: AtomicBool = AtomicBool::new(true);
+static LOG_COMMAND_SENDER: OnceCell<Arc<Mutex<Sender<LoggingCommand>>>> = OnceCell::new();
+
+fn start_central_logger() -> (Sender<LoggingCommand>, JoinHandle<()>) {
+    let (send, recv) = channel();
+    LOG_COMMAND_SENDER.set(Arc::new(Mutex::new(send.clone())));
+    let handle = thread::spawn(move || {
+        let mut central_logger = CentralLoggerOutput::new();
+        loop {
+            let command = match recv.try_recv() {
+                Ok(s) => { s }
+                Err(TryRecvError::Empty) => {
+                    continue
+                }
+                Err(TryRecvError::Disconnected) => break,
+            };
+
+            match command {
+                LoggingCommand::LogString(o, s) => {
+                    central_logger.add_output(o, &s);
+                    central_logger.flush_current_origin();
+                }
+                LoggingCommand::Flush => {
+                    central_logger.flush()
+                }
+                LoggingCommand::Stop => {
+                    break;
+                }
+            }
+        }
+
+        central_logger.flush();
+    });
+    reset();
+    (send, handle)
+}
+
+pub enum LoggingCommand {
+    LogString(Origin, String),
+    Flush,
+    Stop,
+}
+
+pub struct CentralLoggerInput {
+    sender: Sender<LoggingCommand>
+}
+
+assert_impl_all!(CentralLoggerInput: Send, Write);
+
+impl io::Write for CentralLoggerInput {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let string = String::from_utf8_lossy(buf).to_string();
+
+        let origin = thread_origin();
+        // println!("sending from origin: {origin:?}");
+        self.sender.send(LoggingCommand::LogString(origin, string)).map_err(|e| io::Error::new(ErrorKind::Interrupted, e))?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.sender.send(LoggingCommand::Flush).map_err(|e| io::Error::new(ErrorKind::Interrupted, e))
+    }
 }
 
 #[derive(Debug)]
-struct TaskProgressDisplayInner {
-    total_tasks: usize,
-    completed_tasks: usize,
-    running_tasks: Vec<TaskId>,
+pub struct CentralLoggerOutput {
+    origin_buffers: HashMap<Origin, String>,
+    origin_queue: VecDeque<Origin>,
+    previous: Option<Origin>,
+    last_query: Option<Instant>,
 }
 
-pub struct TaskProgress {
-    progress: ProgressBar,
-}
-
-pub struct ThreadBasedLogger {
-    thread_id_to_task: RwLock<HashMap<ThreadId, TaskId>>,
-}
-
-impl ThreadBasedLogger {
+impl CentralLoggerOutput {
     pub fn new() -> Self {
-        Self {
-            thread_id_to_task: Default::default(),
+        Self { origin_buffers: Default::default(), origin_queue: Default::default(), previous: None, last_query: None }
+    }
+
+    pub fn add_output(&mut self, origin: Origin, msg: &str) {
+        let buffer = self.origin_buffers.entry(origin.clone())
+            .or_default();
+        *buffer = format!("{}{}", buffer, msg);
+        if let Some(front) = self.origin_queue.front() {
+            if front != &origin {
+                if self.last_query.unwrap().elapsed() >= Duration::from_millis(1000){
+                    self.origin_queue.pop_front();
+                }
+                self.origin_queue.push_back(origin);
+            }
+            self.last_query = Some(Instant::now());
+        } else {
+            self.origin_queue.push_back(origin);
+        }
+
+    }
+
+    /// Flushes current lines from an origin
+    pub fn flush_current_origin(&mut self) {
+
+        self.last_query = Some(Instant::now());
+        let origin = self.origin_queue.front().cloned().unwrap_or(Origin::None);
+
+        if Some(&origin) != self.previous.as_ref() {
+            println!();
+            match &origin {
+                Origin::Project(p) => {
+                    println!("{}", AssembleFormatter::default().project_status(p, "configuring").unwrap());
+                }
+                Origin::Task(t) => {
+                    println!("{}", AssembleFormatter::default().task_status(t, "").unwrap());
+                }
+                Origin::None => {}
+            }
+        }
+
+        self.previous = Some(origin.clone());
+
+        if let Some(buffer) = self.origin_buffers.get_mut(&origin) {
+            let mut lines = Vec::new();
+            while let Some(position) = buffer.chars().position(|c| c == '\n') {
+                let head = &buffer[..position];
+                let tail = buffer.get((position+1)..).unwrap_or_default();
+
+                lines.push(head.to_string());
+
+                *buffer = tail.to_string();
+            }
+
+            for line in lines {
+                println!("{}", line);
+            }
+
+            if buffer.trim().is_empty() {
+                self.origin_queue.pop_front();
+
+            }
         }
     }
 
-    pub fn logger() -> &'static Self {
-        ROOT_LOGGER.get().unwrap()
-    }
-
-    pub fn register_thread_to_task(&self, id: &TaskId) {
-        let mut result = self.thread_id_to_task.write().unwrap();
-        let thread_id = thread::current().id();
-        result.insert(thread_id, id.clone());
-    }
-
-    pub fn deregister_thread_to_task(&self) {
-        let mut result = self.thread_id_to_task.write().unwrap();
-        let thread_id = thread::current().id();
-        result.remove(&thread_id);
-    }
-
-    pub fn apply(self) -> Result<(), Error> {
-        ROOT_LOGGER.set(self).map_err(|_| Error::RootAlreadySet)?;
-        Ok(())
+    pub fn flush(&mut self) {
+        let drained = self.origin_queue.drain(..).collect::<Vec<_>>();
+        for origin in drained {
+            if let Some(str) = self.origin_buffers.get_mut(&origin) {
+                println!("{origin:?}: {}", str);
+                str.clear();
+            }
+        }
+        stdout().flush().unwrap();
     }
 }
 
-static ROOT_LOGGER: OnceCell<ThreadBasedLogger> = OnceCell::new();
 
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("Root logger already set")]
-    RootAlreadySet,
-    #[error(transparent)]
-    SetLoggerError(#[from] SetLoggerError),
-}

--- a/crates/assemble-core/src/project.rs
+++ b/crates/assemble-core/src/project.rs
@@ -30,7 +30,7 @@ use std::sync::{
     Arc, Mutex, MutexGuard, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard, TryLockError,
 };
 use tempfile::TempDir;
-use crate::logging::{in_project, reset};
+use crate::logging::{LOGGING_CONTROL, LoggingControl};
 
 pub mod buildable;
 pub mod configuration;
@@ -119,7 +119,7 @@ impl Project {
         ProjectError: From<<Id as TryInto<ProjectId>>::Error>,
     {
         let id = id.try_into()?;
-        in_project(id.clone());
+        LOGGING_CONTROL.in_project(id.clone());
         let factory = TaskIdFactory::new(id.clone());
         let mut build_dir = Prop::new(id.join("buildDir")?);
         build_dir.set(path.as_ref().join("build"))?;
@@ -146,7 +146,7 @@ impl Project {
                 Ok(())
             })?;
         }
-        reset();
+        LOGGING_CONTROL.reset();
         Ok(project)
     }
 

--- a/crates/assemble-core/src/project.rs
+++ b/crates/assemble-core/src/project.rs
@@ -30,6 +30,7 @@ use std::sync::{
     Arc, Mutex, MutexGuard, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard, TryLockError,
 };
 use tempfile::TempDir;
+use crate::logging::{in_project, reset};
 
 pub mod buildable;
 pub mod configuration;
@@ -118,6 +119,7 @@ impl Project {
         ProjectError: From<<Id as TryInto<ProjectId>>::Error>,
     {
         let id = id.try_into()?;
+        in_project(id.clone());
         let factory = TaskIdFactory::new(id.clone());
         let mut build_dir = Prop::new(id.join("buildDir")?);
         build_dir.set(path.as_ref().join("build"))?;
@@ -144,6 +146,7 @@ impl Project {
                 Ok(())
             })?;
         }
+        reset();
         Ok(project)
     }
 

--- a/crates/assemble-core/src/task/executable.rs
+++ b/crates/assemble-core/src/task/executable.rs
@@ -69,7 +69,7 @@ impl<T: 'static + Task + Send + Debug> Executable<T> {
     where
         B::Buildable: 'static,
     {
-        debug!("adding depends ordering for {:?}", self);
+        trace!("adding depends ordering for {:?}", self);
         let buildable = TaskOrdering::depends_on(buildable);
         self.task_ordering.push(buildable);
     }
@@ -176,7 +176,7 @@ impl<T: Task + Send + Debug> IntoBuildable for &Executable<T> {
     type Buildable = BuiltByContainer;
 
     fn into_buildable(self) -> Self::Buildable {
-        debug!("Creating BuiltByContainer for {:?}", self);
+        trace!("Creating BuiltByContainer for {:?}", self);
         let mut built_by = BuiltByContainer::new();
         built_by.add(self.task_id.clone());
         for ordering in self
@@ -236,7 +236,6 @@ impl<T: 'static + Task + Send + Debug> ExecutableTask for Executable<T> {
         let work = if !inputs_up_to_date {
             self.work().set_up_to_date(false);
             (|| -> BuildResult {
-                info!("{}", format!("> Task {}", self.task_id()).bold());
                 let actions = self.actions()?;
 
                 for mut action in actions {

--- a/crates/assemble-core/src/task/lazy_task.rs
+++ b/crates/assemble-core/src/task/lazy_task.rs
@@ -78,7 +78,7 @@ impl<T: Task + Send + Debug + 'static> ResolveTask for LazyTask<T> {
     type Executable = Executable<T>;
 
     fn resolve_task(self, project: &SharedProject) -> ProjectResult<Executable<T>> {
-        debug!("Resolving task {}", self.task_id.as_ref());
+        trace!("Resolving task {}", self.task_id.as_ref());
         let task = project.with(|project| T::new(self.task_id.as_ref(), project))?;
         let mut executable = Executable::new(self.shared.unwrap().clone(), task, self.task_id);
 
@@ -241,7 +241,7 @@ impl<T: Task + Send + Debug + 'static> Debug for TaskHandle<T> {
 
 impl<T: Task + Send + Debug + 'static> Buildable for TaskHandle<T> {
     fn get_dependencies(&self, project: &Project) -> Result<HashSet<TaskId>, ProjectError> {
-        debug!("Getting dependencies for {:?}", self);
+        trace!("Getting dependencies for {:?}", self);
         let mut guard = self.connection.lock()?;
         let configured = guard.configured(&project.as_shared())?;
         configured.into_buildable().get_dependencies(project)

--- a/crates/assemble-core/src/unstable/text_factory.rs
+++ b/crates/assemble-core/src/unstable/text_factory.rs
@@ -3,6 +3,7 @@
 use std::fmt;
 use std::fmt::{Display, Formatter, Write};
 use colored::Colorize;
+use crate::identifier::{ProjectId, TaskId};
 
 pub mod list;
 
@@ -40,6 +41,24 @@ impl<W: Write> AssembleFormatter<W> {
         LessImportant {
             factory: self
         }
+    }
+
+    /// Print some sort of task status
+    pub fn project_status<S : ToString>(mut self, id: &ProjectId, status: S) -> Result<Self, fmt::Error> {
+        let mut formatted = format!("> {} {}", status.to_string(), id).bold().to_string();
+        write!(self, "{}", formatted)?;
+        Ok(self)
+    }
+
+    /// Print some sort of task status
+    pub fn task_status<S : ToString>(mut self, id: &TaskId, status: S) -> Result<Self, fmt::Error> {
+        let mut formatted = format!("> Task {}", id).bold().to_string();
+        let status = status.to_string();
+        if !status.trim().is_empty() {
+            formatted = format!("{} - {}", formatted, status);
+        }
+        write!(self, "{}", formatted)?;
+        Ok(self)
     }
 
     /// Finishes the factory, returning the writer that this factory was wrapping
@@ -82,3 +101,4 @@ impl<'f, W: Write> Write for LessImportant<'f, W> {
         write!(self.factory, "{}", s.yellow())
     }
 }
+

--- a/crates/assemble-freight/examples/java_like_project.rs
+++ b/crates/assemble-freight/examples/java_like_project.rs
@@ -13,7 +13,7 @@ use std::fmt::{Debug, Formatter};
 use std::process::exit;
 use log::info;
 use assemble_core::exception::BuildException;
-use assemble_core::logging::{in_project, stop_logging};
+use assemble_core::logging::{LOGGING_CONTROL};
 
 fn main() {
     if execute_assemble::<(), FreightError, _>(|| {
@@ -106,7 +106,7 @@ fn main() {
         }
 
         if let Some(handle) = handle {
-            stop_logging();
+            LOGGING_CONTROL.stop_logging();
             handle.join().unwrap();
         }
 

--- a/crates/assemble-freight/examples/java_like_project.rs
+++ b/crates/assemble-freight/examples/java_like_project.rs
@@ -41,11 +41,11 @@ fn main() {
             classes.set_description("lifecycle task to create all classes in main source set\nCalls the compile task and process resources task for the source set");
             classes.set_group("build");
             classes.do_first(|_, _| {
-                println!("running lifecycle task classes");
+                info!("running lifecycle task classes");
                 Ok(())
             })?;
             classes.do_last(|e, _| {
-                println!("did_work: {}", e.work().did_work());
+                info!("did_work: {}", e.work().did_work());
                 Ok(())
             })?;
             Ok(())

--- a/crates/assemble-freight/examples/java_like_project.rs
+++ b/crates/assemble-freight/examples/java_like_project.rs
@@ -13,10 +13,13 @@ use std::fmt::{Debug, Formatter};
 use std::process::exit;
 use log::info;
 use assemble_core::exception::BuildException;
+use assemble_core::logging::{in_project, stop_logging};
 
 fn main() {
     if execute_assemble::<(), FreightError, _>(|| {
         let args: FreightArgs = FreightArgs::parse();
+        let handle = args.log_level.init_root_logger().ok().flatten();
+
         let project = Project::with_id("java_like")?;
 
         project.with_mut(|project| {
@@ -100,6 +103,11 @@ fn main() {
 
                 }
             }
+        }
+
+        if let Some(handle) = handle {
+            stop_logging();
+            handle.join().unwrap();
         }
 
         Ok(())

--- a/crates/assemble-freight/src/utils.rs
+++ b/crates/assemble-freight/src/utils.rs
@@ -13,6 +13,7 @@ use std::io;
 use std::marker::PhantomData;
 use std::num::{IntErrorKind, ParseIntError};
 use std::time::{Duration, Instant};
+use log::SetLoggerError;
 use thiserror::Error;
 
 /// Represents the result of a task
@@ -83,6 +84,8 @@ pub enum FreightError {
     ConstructError(#[from] ConstructionError),
     #[error(transparent)]
     InvalidId(#[from] InvalidId),
+    #[error(transparent)]
+    SetLoggerError(#[from] SetLoggerError)
 }
 
 pub type FreightResult<T> = Result<T, FreightError>;


### PR DESCRIPTION
Task and project headers in output is now automatically generated.

Closes #6 